### PR TITLE
Optional xjb files

### DIFF
--- a/bin/jaxb2ruby
+++ b/bin/jaxb2ruby
@@ -32,6 +32,10 @@ options = {}
 parser = OptionParser.new do |opts|
   opts.banner = "usage: #{File.basename($0)} [options] schema"
 
+  opts.on("-b", "--binding=FILE", "specify external bindings files (xjb). Each FILE must have its own -b.") do |opt|
+    (options[:bindings] ||= []).push(opt)
+  end
+
   opts.on("-c", "--classes=MAP1[,MAP2,...]", Array, "XML Schema type to Ruby class mappings", "MAP can be a string in the form type=class or a YAML file of type/class pairs") do |typemap|
     options[:typemap] = mapping_option(typemap)
   end

--- a/lib/jaxb2ruby/converter.rb
+++ b/lib/jaxb2ruby/converter.rb
@@ -16,7 +16,7 @@ module JAXB2Ruby
 
     def initialize(schema, options = {})
       raise ArgumentError, "cannot access schema: #{schema}" unless File.file?(schema) and File.readable?(schema)
-      @xjc = XJC.new(schema, :xjc => options[:xjc], :wsdl => !!options[:wsdl], :jvm => options[:jvm])
+      @xjc = XJC.new(schema, :xjc => options[:xjc], :wsdl => !!options[:wsdl], :jvm => options[:jvm], bindings: options[:bindings])
 
       @namespace = options[:namespace] || {}
       raise ArgumentError, "namespace mapping must be a Hash" unless @namespace.is_a?(Hash)

--- a/lib/jaxb2ruby/xjc.rb
+++ b/lib/jaxb2ruby/xjc.rb
@@ -32,7 +32,8 @@ module JAXB2Ruby
 
     def xjc
       options = @schema.end_with?(".wsdl") || @options[:wsdl] ? "-wsdl " : ""
-      options << "-extension -npa -d :sources :schema -b :config"
+      bindings = (@options[:bindings] || []).map { |binding| "-b #{binding}"}.join(" ")
+      options << "-extension -npa -d :sources :schema -b :config #{bindings}"
       options << @options[:jvm].map { |opt| " -J#{opt}" }.join(" ") if @options[:jvm]
 
       line = Cocaine::CommandLine.new(@options[:xjc] || "xjc", options)

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -2,6 +2,29 @@ require "spec_helper"
 require "jaxb2ruby/type_util"
 
 describe JAXB2Ruby::Converter do
+  it "errors when there elements with names causing a collision" do
+    assert_raises do
+      convert("conflict")
+    end
+  end
+
+  it "optionally accepts xjb files for binding" do
+    path = File.expand_path("../fixtures/conflict_binding.xjb", __FILE__)
+    hash = class_hash(convert("conflict", bindings: [path]))
+
+    _(hash["A"]).must_be_instance_of(JAXB2Ruby::RubyClass)
+    element_a = hash['A'].element.children.first
+    _(element_a).must_be_instance_of(JAXB2Ruby::Element)
+    _(element_a.accessor).must_equal('value')
+    _(element_a.type).must_equal('String')
+
+    _(hash["B"]).must_be_instance_of(JAXB2Ruby::RubyClass)
+    element_b = hash['B'].element.children.first
+    _(element_b).must_be_instance_of(JAXB2Ruby::Element)
+    _(element_b.accessor).must_equal('value')
+    _(element_b.type).must_equal('Float')
+  end
+
   it "creates ruby classes" do
     classes = convert("address")
     classes.size.must_equal(2)

--- a/spec/fixtures/conflict.xsd
+++ b/spec/fixtures/conflict.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+	<xs:element name="A">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Value"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="B">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="value"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:element name="Value">
+		<xs:simpleType>
+			<xs:restriction base="xs:string"/>
+		</xs:simpleType>
+	</xs:element>
+	<xs:element name="value">
+		<xs:simpleType>
+			<xs:restriction base="xs:float"/>
+		</xs:simpleType>
+	</xs:element>
+</xs:schema>

--- a/spec/fixtures/conflict_binding.xjb
+++ b/spec/fixtures/conflict_binding.xjb
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<jxb:bindings xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jxb="http://java.sun.com/xml/ns/jaxb" version="2.1">
+  <jxb:bindings schemaLocation="conflict.xsd">
+    <jxb:bindings node="//xs:element[@name='value']">
+      <jxb:factoryMethod name="MyName"/>
+    </jxb:bindings>
+  </jxb:bindings>
+</jxb:bindings>


### PR DESCRIPTION
We came across some xsd files recently that had multiple elements with the same name, only one version was lower case. For example `Name` and `name`.

This creates conflicts in `xjc`, unless there is are binding definitions to work around this.  So we opened up the gem to take `-b` options in the same manner as `xjc`.

